### PR TITLE
[AC-255] Remove null bytes from xmpString

### DIFF
--- a/index.js
+++ b/index.js
@@ -148,7 +148,7 @@
 
 	function read(xmpString) {
 	    try {
-	        const doc = getDocument(xmpString);
+	        const doc = getDocument(xmpString.replace(/\0/g, ""));
 	        const rdf = getRDF(doc);
 
 	        const xmp = parseXMPObject(convertToObject(rdf, true));

--- a/src/xmp-parser.js
+++ b/src/xmp-parser.js
@@ -24,7 +24,7 @@ const tagTypes = {
 
 function read(xmpString) {
     try {
-        const doc = getDocument(xmpString);
+        const doc = getDocument(xmpString.replace(/\0/g, ""));
         const rdf = getRDF(doc);
 
         const xmp = parseXMPObject(convertToObject(rdf, true));


### PR DESCRIPTION
The xmp segment had a null byte at the end. The tests don't catch this because apparently in nodejs it works. In the browser the dom parser failed.