### PR TITLE
[EN-1363] Remove fs import from exifr

### DIFF
--- a/index.js
+++ b/index.js
@@ -812,7 +812,9 @@
 		fs() {
 			//  FsReader should only be used in Node environments anyway, but we add this here as a sanity check
 			if (isNode) {
-				const _fs = eval('require')('fs'); // This CommonJs require only runs in node, so it won't cause any issues in the browser
+				// This CommonJs require only runs in node, so it won't cause any issues in the browser
+				// Doing it this way to avoid bundling fs module in the browser build
+				const _fs = eval('require')('fs');
 				return typeof _fs !== 'undefined' ? _fs.promises : undefined;
 			}
 			throw new Error('Node.js fs module is not available outside of node.');

--- a/index.js
+++ b/index.js
@@ -1,10 +1,8 @@
 (function (global, factory) {
-	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('fs')) :
-	typeof define === 'function' && define.amd ? define('exifr', ['exports', 'fs'], factory) :
-	(global = global || self, factory(global.exifr = {}, global.fs));
-}(this, function (exports, _fs) { 'use strict';
-
-	_fs = _fs && _fs.hasOwnProperty('default') ? _fs['default'] : _fs;
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
+	typeof define === 'function' && define.amd ? define('exifr', ['exports'], factory) :
+	(global = global || self, factory(global.exifr = {}));
+}(this, function (exports) { 'use strict';
 
 	var hasBuffer = typeof Buffer !== 'undefined';
 	var isBrowser = typeof navigator !== 'undefined';
@@ -658,9 +656,6 @@
 		return options
 	}
 
-	var fs = typeof _fs !== 'undefined' ? _fs.promises : undefined;
-
-
 	// TODO: - minified UMD bundle
 	// TODO: - offer two UMD bundles (with tags.mjs dictionary and without)
 	// TODO: - API for including 3rd party XML parser
@@ -771,7 +766,7 @@
 	// or it falls back to reading the whole file if enabled with options.allowWholeFile.
 
 	class ChunkedReader {
-		
+
 		constructor(input, options) {
 			this.input = input;
 			this.options = options;
@@ -814,9 +809,17 @@
 
 
 	class FsReader extends ChunkedReader {
+		fs() {
+			//  FsReader should only be used in Node environments anyway, but we add this here as a sanity check
+			if (isNode) {
+				const _fs = eval('require')('fs'); // This CommonJs require only runs in node, so it won't cause any issues in the browser
+				return typeof _fs !== 'undefined' ? _fs.promises : undefined;
+			}
+			throw new Error('Node.js fs module is not available outside of node.');
+		}
 
 		async readWhole() {
-			let buffer = await fs.readFile(this.input);
+			let buffer = await this.fs().readFile(this.input);
 			let tiffPosition = findTiff(buffer);
 			return [buffer, tiffPosition]
 		}
@@ -828,7 +831,7 @@
 		}
 
 		async readChunked() {
-			this.fh = await fs.open(this.input, 'r');
+			this.fh = await this.fs().open(this.input, 'r');
 			try {
 				var seekChunk = Buffer.allocUnsafe(this.options.seekChunkSize);
 				var {bytesRead} = await this.fh.read(seekChunk, 0, seekChunk.length, null);

--- a/src/fs.mjs
+++ b/src/fs.mjs
@@ -1,0 +1,21 @@
+import {isNode} from './buff-util.mjs';
+
+let _fs = undefined; // lazy-loaded
+
+/**
+ * A safe way of accessing the Node.js fs module. This shouldn't be used in code run by the browser.
+ */
+export function fs() {
+    if (!isNode) {
+        throw new Error('Node.js fs module is not available outside of node.');
+    }
+    if (!_fs) {
+        // Doing it with eval() avoids web bundlers from replacing it with a generic import and bundling the module.
+        const fs = eval('require')('fs');
+        _fs = fs != null ? fs.promises : undefined;
+    }
+    if (!_fs) {
+        throw new Error('Node.js fs module is not available.');
+    }
+    return _fs;
+}

--- a/src/reader.mjs
+++ b/src/reader.mjs
@@ -1,11 +1,6 @@
 import {findTiff} from './parser.mjs'
 import {hasBuffer, isBrowser, isNode} from './buff-util.mjs'
 import {processOptions} from './options.mjs'
-// Sigh... Ugly, ugly, ugly. FS Promises are experimental plus this code needs to be isomorphic
-// and work without fs altogether.
-import _fs from 'fs'
-var fs = typeof _fs !== 'undefined' ? _fs.promises : undefined
-
 
 // TODO: - minified UMD bundle
 // TODO: - offer two UMD bundles (with tags.mjs dictionary and without)
@@ -117,7 +112,7 @@ export default class Reader {
 // or it falls back to reading the whole file if enabled with options.allowWholeFile.
 
 class ChunkedReader {
-	
+
 	constructor(input, options) {
 		this.input = input
 		this.options = options
@@ -160,9 +155,19 @@ class ChunkedReader {
 
 
 class FsReader extends ChunkedReader {
+	fs() {
+		//  FsReader should only be used in Node environments anyway, but we add this here as a sanity check
+		if (isNode) {
+			// This CommonJs require only runs in node, so it won't cause any issues in the browser
+			// Doing it this way to avoid bundling fs module in the browser build
+			const _fs = eval('require')('fs');
+			return typeof _fs !== 'undefined' ? _fs.promises : undefined;
+		}
+		throw new Error('Node.js fs module is not available outside of node.');
+	}
 
 	async readWhole() {
-		let buffer = await fs.readFile(this.input)
+		let buffer = await this.fs().readFile(this.input)
 		let tiffPosition = findTiff(buffer)
 		return [buffer, tiffPosition]
 	}
@@ -174,7 +179,7 @@ class FsReader extends ChunkedReader {
 	}
 
 	async readChunked() {
-		this.fh = await fs.open(this.input, 'r')
+		this.fh = await this.fs().open(this.input, 'r')
 		try {
 			var seekChunk = Buffer.allocUnsafe(this.options.seekChunkSize)
 			var {bytesRead} = await this.fh.read(seekChunk, 0, seekChunk.length, null)

--- a/src/reader.mjs
+++ b/src/reader.mjs
@@ -1,6 +1,7 @@
 import {findTiff} from './parser.mjs'
 import {hasBuffer, isBrowser, isNode} from './buff-util.mjs'
 import {processOptions} from './options.mjs'
+import {fs} from './fs.mjs'
 
 // TODO: - minified UMD bundle
 // TODO: - offer two UMD bundles (with tags.mjs dictionary and without)
@@ -155,19 +156,8 @@ class ChunkedReader {
 
 
 class FsReader extends ChunkedReader {
-	fs() {
-		//  FsReader should only be used in Node environments anyway, but we add this here as a sanity check
-		if (isNode) {
-			// This CommonJs require only runs in node, so it won't cause any issues in the browser
-			// Doing it this way to avoid bundling fs module in the browser build
-			const _fs = eval('require')('fs');
-			return typeof _fs !== 'undefined' ? _fs.promises : undefined;
-		}
-		throw new Error('Node.js fs module is not available outside of node.');
-	}
-
 	async readWhole() {
-		let buffer = await this.fs().readFile(this.input)
+		let buffer = await fs().readFile(this.input)
 		let tiffPosition = findTiff(buffer)
 		return [buffer, tiffPosition]
 	}
@@ -179,7 +169,7 @@ class FsReader extends ChunkedReader {
 	}
 
 	async readChunked() {
-		this.fh = await this.fs().open(this.input, 'r')
+		this.fh = await fs().open(this.input, 'r')
 		try {
 			var seekChunk = Buffer.allocUnsafe(this.options.seekChunkSize)
 			var {bytesRead} = await this.fh.read(seekChunk, 0, seekChunk.length, null)


### PR DESCRIPTION
I saw that the only place where `fs` was being used was the `FsReader`. Which was already being kept from being run on the browser by an `isNode` check. I decided it would be pretty useless to find an isomorphic browser fs drop-in replacement because it wouldn't even get used.

So instead I decided to move the `fs` import into a lazy loaded variable in `fs.mjs`. It uses `eval('require')` so that the web bundler won't try to replace it with something else, this is also how we do it for the `xmldom` import. The lazy loading checks for the right environment so that the browser won't ever try to run that code.

With this fix we can still use exifr on node if we ever need to because the `isNode` check will pass and `fs` will be used as usual. And it will still keep working on the browser because the `isNode` check will never pass and it will never try to require fs, so it will never run in to those issues.