### PR TITLE
Import & use XMLDomParser if needed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sitemark/exifr",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "📑 The fastest and most versatile JavaScript EXIF reading library.",
   "author": "Mike Kovarik",
   "license": "MIT",

--- a/src/dom-parser.mjs
+++ b/src/dom-parser.mjs
@@ -2,6 +2,7 @@
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { DOMParser as XMLDOMParser } from "@xmldom/xmldom";
 
 export default {
     get
@@ -11,9 +12,7 @@ function get() {
     if (typeof DOMParser !== 'undefined') {
         return DOMParser;
     }
-    try {
-        return eval('require')('@xmldom/xmldom').DOMParser; // This stops Webpack from replacing the require with a generic import and bundling the module.
-    } catch (error) {
-        return undefined;
-    }
+    // If your code uses web workers, workerpool or runs in node, then it will need to use xmldom
+    // If the dependency @xmldom/xmldom does not exist then this will return undefined
+    return XMLDOMParser;
 }


### PR DESCRIPTION
Change:

- No longer dynamically import @xmldom/xmldom

Why this is okay to do:

- Previously we did not want to import @xmldom/xmldom into Web to not import a useless package. However, now web needs xmldom as well if this is called from within a web worker. So xmldom is now **always** needed in both web and node version of the application so xmldom will always need to be included regardless. So now we simply choose to use the built-in DOMParser if it's available and otherwise we use the one from xmldom without any fancy dynamic imports