### PR TITLE
Update package.json to point to correct homepage

### DIFF
--- a/.changeset/weak-ads-vanish.md
+++ b/.changeset/weak-ads-vanish.md
@@ -1,0 +1,5 @@
+---
+"@sitemark/exifr": patch
+---
+
+Update the project homepage in package.json

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "buffer",
     "uint8array"
   ],
-  "homepage": "https://exifr.netlify.com",
+  "homepage": "https://sitemark.com",
   "bugs": "https://github.com/sitemark/exifr/issues",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The homepage in package.json now correctly links to sitemark instead of a dead netlify link.